### PR TITLE
jsp(x) speed bug fix

### DIFF
--- a/templates/tunnel.jsp
+++ b/templates/tunnel.jsp
@@ -219,7 +219,7 @@
                     System.arraycopy(buf.array(), 0, data, 0, bytesRead);
                     out.write(b64en(data));
                     out.flush();
-                    buf.clear();
+                    ((java.nio.Buffer)buf).clear();
                     bytesRead = socketChannel.read(buf);
                 }
                 response.setHeader("X-STATUS", "OK");

--- a/templates/tunnel.jsp
+++ b/templates/tunnel.jsp
@@ -218,6 +218,8 @@
                     byte[] data = new byte[bytesRead];
                     System.arraycopy(buf.array(), 0, data, 0, bytesRead);
                     out.write(b64en(data));
+                    out.flush();
+                    buf.clear();
                     bytesRead = socketChannel.read(buf);
                 }
                 response.setHeader("X-STATUS", "OK");

--- a/templates/tunnel.jspx
+++ b/templates/tunnel.jspx
@@ -218,6 +218,8 @@
                     byte[] data = new byte[bytesRead];
                     System.arraycopy(buf.array(), 0, data, 0, bytesRead);
                     out.write(b64en(data));
+                    out.flush();
+                    ((java.nio.Buffer)buf).clear();
                     bytesRead = socketChannel.read(buf);
                 }
                 response.setHeader("X-STATUS", "OK");


### PR DESCRIPTION
`buf.clear();` 会重置缓冲区的主要索引值，不必为了每次读写都创建新的缓冲区；如果在下次写入之前不这么做，那么下次写入总是失败的。这将导致while循环总是只执行一次，每次http链接只能传输513字节长度的数据，降低效率。

以下是测试数据：
未添加`buf.clear();`时：
![1](https://user-images.githubusercontent.com/32238570/119695328-a2b82300-be80-11eb-88ec-0d73ecf629c2.png)

让我们看看while循环执行的情况：
![2](https://user-images.githubusercontent.com/32238570/119694270-a9926600-be7f-11eb-84b8-42348ec1f2b7.png)
显然，第二次写buf总是失败，长度为0，导致while循环只能执行1次。数据将会被分成多次http连接传递，降低传输效率。

添加`buf.clear();`时：
![3](https://user-images.githubusercontent.com/32238570/119695206-8a480880-be80-11eb-806e-2f6e1871aed8.png)

单次可传递数据明显变多：
![4](https://user-images.githubusercontent.com/32238570/119694762-1d347300-be80-11eb-8ab9-60c26c263b63.png)

curl 传输速度对比：
![image](https://user-images.githubusercontent.com/32238570/119694905-42c17c80-be80-11eb-948d-4d350cd9b6f5.png)


