### PR TITLE
fix custom cookie parameter (`-c`, `--cookie`) not work on some situation

### DIFF
--- a/neoreg.py
+++ b/neoreg.py
@@ -598,6 +598,7 @@ def askNeoGeorg(conn, connectURLs, redirectURLs, force_redirect):
 
     if INIT_COOKIE:
         headers['Cookie'] = INIT_COOKIE
+        HEADERS.update({'Cookie': INIT_COOKIE})
 
     need_exit = False
     try:
@@ -627,6 +628,8 @@ def askNeoGeorg(conn, connectURLs, redirectURLs, force_redirect):
                                 cookie += '{}={};'.format(k, v)
                             HEADERS.update({'Cookie' : cookie})
                             log.warning("[Ask NeoGeorg] Automatically append Cookies: {}".format(cookie))
+                        elif INIT_COOKIE:
+                            pass
                         else:
                             log.error('[Ask NeoGeorg] There is no valid cookie return')
                             need_exit = True


### PR DESCRIPTION
I noticed that the custom cookie parameter is not working in some situation.

For example, I use a LFI vulnerability on DVWA to test this bug.

It needs to login to get the vulnerable web page, so I need to login and get the PHPSESSID first.
And then, I need to pass the cookie to Neo-reGeorg custom cookie field.

But it will exit on `neoreg.py#631`, because it would not get any `Set-Cookie` header from response. (I already set the `PHPSESSID` cookie, so it would never get that.)
Here is the first bug.

And then I comment `neoreg.py#632` to make this program go ahead for test.
When I proxied some traffic, it would get the second bug.
It show me "[HTTP] Response Format Error: <something>" (`neoreg.py#438`).
This is because of the value `rinfo` is `None`.

When I checked what is causing this, I noticed that the `response.content` always show me a DVWA login page, so I confirmed this issue is the parameter `--cookie` would not send my custom cookie to the remote correctly.

I correct these two bugs according this PR, please review it ~
If you have any problem, please let me know.
Thank you for developing this so wonderful tool.