### PR TITLE
update: Add curl-cffi compatability

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -18,6 +18,9 @@
 
 ## python dependencies
 ```ruby
+python -m pip install curl-cffi
+
+# For older python
 python -m pip install requests requests[socks]
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@
 
 ## python 依赖
 ```ruby
+python -m pip install curl-cffi
+
 python -m pip install requests requests[socks]
 ```
 


### PR DESCRIPTION
[curl-cffi](https://github.com/lexiforest/curl_cffi) is curl-based library that almost compatible with requests, but its a little bit faster

And its still possible to use original requests module if there an any issue

here are my quick benchmark:

```bash
# use original requests..
$ time bash -c 'for i in {1..10}; do proxychains4 -f ~/proxy.conf curl -o /dev/null -s [redacted]; done'

real	0m5.454s
user	0m0.062s
sys	0m0.066s

# use curl-cffi...
$ time bash -c 'for i in {1..10}; do proxychains4 -f ~/proxy.conf curl -o /dev/null -s [redacted]; done'

real	0m4.584s
user	0m0.059s
sys	0m0.085s
```

I guess its related with #53 