### PR TITLE
fix(csharp): StrTr is quadratic, stalling the tunnel on large responses

### DIFF
--- a/templates/tunnel.ashx
+++ b/templates/tunnel.ashx
@@ -9,15 +9,19 @@ using System.Net.Sockets;
 
 public class GenericHandler1 : IHttpHandler, System.Web.SessionState.IRequiresSessionState {
     public String StrTr(string input, string frm, string to) {
-        String r = "";
+        char[] map = new char[128];
+        for(int i=0; i < 128; i++)
+            map[i] = (char) i;
+        int n = frm.Length < to.Length ? frm.Length : to.Length;
+        for(int i=0; i < n; i++)
+            if (frm[i] < 128)
+                map[frm[i]] = to[i];
+        char[] r = new char[input.Length];
         for(int i=0; i < input.Length; i++) {
-            int index = frm.IndexOf(input[i]);
-            if(index != -1)
-                r += to[index];
-            else
-                r += input[i];
+            char c = input[i];
+            r[i] = c < 128 ? map[c] : c;
         }
-        return r;
+        return new String(r);
     }
 
     public static Object[] blv_decode(byte[] data) {

--- a/templates/tunnel.aspx
+++ b/templates/tunnel.aspx
@@ -6,15 +6,19 @@
 <%@ Import Namespace="System.Collections" %>
 <script runat="server">
     public String StrTr(string input, string frm, string to) {
-        String r = "";
+        char[] map = new char[128];
+        for(int i=0; i < 128; i++)
+            map[i] = (char) i;
+        int n = frm.Length < to.Length ? frm.Length : to.Length;
+        for(int i=0; i < n; i++)
+            if (frm[i] < 128)
+                map[frm[i]] = to[i];
+        char[] r = new char[input.Length];
         for(int i=0; i< input.Length; i++) {
-            int index = frm.IndexOf(input[i]);
-            if(index != -1)
-                r += to[index];
-            else
-                r += input[i];
+            char c = input[i];
+            r[i] = c < 128 ? map[c] : c;
         }
-        return r;
+        return new String(r);
     }
 
     public static Object[] blv_decode(byte[] data) {

--- a/templates/tunnel.cs
+++ b/templates/tunnel.cs
@@ -241,17 +241,22 @@ namespace Neoreg
         
         public String StrTr(string input, string frm, string to)
         {
-            String r = "";
+            char[] map = new char[128];
+            for (int i = 0; i < 128; i++)
+                map[i] = (char) i;
+            int n = frm.Length < to.Length ? frm.Length : to.Length;
+            for (int i = 0; i < n; i++)
+                if (frm[i] < 128)
+                    map[frm[i]] = to[i];
+
+            char[] r = new char[input.Length];
             for (int i = 0; i < input.Length; i++)
             {
-                int index = frm.IndexOf(input[i]);
-                if (index != -1)
-                    r += to[index];
-                else
-                    r += input[i];
+                char c = input[i];
+                r[i] = c < 128 ? map[c] : c;
             }
 
-            return r;
+            return new String(r);
         }
 
         public static Object[] blv_decode(byte[] data)


### PR DESCRIPTION
## Problem

`StrTr` in `tunnel.aspx`, `tunnel.ashx` and `tunnel.cs` is the same method copied verbatim three times. It accumulates its result with `r += c` inside the per-character loop. C# strings are immutable, so every character reallocates and recopies the entire accumulated string — O(n²) in both time and allocation. A smaller compounding problem: `frm.IndexOf(input[i])` scans the 64-character charlist linearly for every character.

At the default `--max-read-size 512KB` (699,052 base64 characters), a single response takes **158.8 seconds** of pure CPU on the target and allocates roughly **489 GB**. In practice this makes the C# tunnels look hung on large responses.

The other templates were checked and are unaffected: `tunnel.php` uses the native `strtr()`, `tunnel.js` a `Map` over a `Buffer`, `tunnel.go` a `map[byte]byte`, and `NeoreGeorg.java` (used by `tunnel.jsp`/`.jspx`) a 256-entry table with `StringBuffer`.

## Fix

Replaced with a 128-entry lookup table and a preallocated `char[]`. All three files already import `System.Text`, but `char[]` measured 1.4–1.55x faster than `StringBuilder` at identical allocation, so `char[]` was used.

## Benchmark (.NET 8, Ubuntu 24.04)

| Payload | b64 chars | before | after |
|---|---|---|---|
| hello probe | 40 | 0.002 ms | 0.002 ms |
| `--read-buff 7KB` (default POST) | 9,560 | 11.5 ms | 0.018 ms |
| `--read-buff 50KB` (max POST) | 68,268 | 620.7 ms | 0.183 ms |
| `--max-read-size 512KB` (default response) | 699,052 | 158,810 ms | 1.32 ms |

Timing grows ~4x per doubling of input, confirming quadratic behaviour. The 512KB row is measured, not extrapolated.

Fixing only the string concatenation and keeping the `IndexOf` scan gets to 12.4 ms — the lookup table is where most of the win comes from.

## Correctness

The patched method was extracted verbatim from each of the three files and its output diffed against the original implementation over 13,500 randomized cases, covering charlist characters, `=` padding, arbitrary ASCII and non-ASCII passthrough, plus base64 encode/decode round-trips through `Convert.*Base64String`. Output is **byte-identical**. `neoreg.py generate` still emits all eight templates correctly.